### PR TITLE
Add ability to select coverage method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+Change Log
+==========
+
+Version Next
+----------------------------
+
+
+Version 1.0.0
+----------------------------
+
+* Add 'coverageType' property and set default to ':line' instead of ':instruction'. (API Change)
+* Add Named Parameters for all functions; users must now specify the name of each parameter being passed in. (Breaking Change)
+* Remove 'report' function; users must now use 'reportKover' or 'reportJacoco' directly. (Breaking Change)
+
+Version 0.0.7
+----------------------------
+
+* Add separate variables for the 'failIfUnderProjectThreshold' and 'failIfUnderFileThreshold'.
+
+Version 0.0.6
+----------------------------
+
+* Target Ruby 2.7.2.
+* Update publishing logic.
+
+Version 0.0.5
+----------------------------
+
+* Add support for Kover test reports.
+
+Version 0.0.4
+----------------------------
+
+* Migrate to Github Actions.
+
+Version 0.0.3
+----------------------------
+
+* Initial release.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-shroud (0.0.7)
+    danger-shroud (1.0.0)
       danger-plugin-api (~> 1.0)
       nokogiri
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     - [Parameters](#parameters-1)
     - [Examples](#examples-1)
   - [Development](#development)
+  - [Versioning](#versioning)
 
 # danger-shroud
 
@@ -39,6 +40,7 @@ You can use the following parameters to control how shroud operates:
 | modifiedFileThreshold       | Integer | defines the required percentage of files modified in a PR for a passing build.              | default `90`                 |
 | failIfUnderProjectThreshold | Boolean | if true, will fail builds that are under the provided thresholds. if false, will only warn. | default `true`               |
 | failIfUnderFileThreshold    | Boolean | if true, will fail builds that are under the provided thresholds. if false, will only warn. | default `true`               |
+| coverageType                | enum    | the type of coverage to use (:branch, :class, :instruction, :line, and :method).            | default `:line`       |
 
 ### Examples
 
@@ -80,6 +82,7 @@ You can use the following parameters to control how shroud operates:
 | modifiedFileThreshold       | Integer | defines the required percentage of files modified in a PR for a passing build.              | default `90`                  |
 | failIfUnderProjectThreshold | Boolean | if true, will fail builds that are under the provided thresholds. if false, will only warn. | default `true`                |
 | failIfUnderFileThreshold    | Boolean | if true, will fail builds that are under the provided thresholds. if false, will only warn. | default `true`                |
+| coverageType                | enum    | the type of coverage to use (:branch, :class, :instruction, :line, and :method).            | default `:line`        |
 
 ### Examples
 
@@ -116,3 +119,23 @@ shroud.reportJacoco moduleName: 'Module Name', file: 'path/to/jacoco/report.xml'
 3. Run `bundle exec rake spec` to run the tests.
 4. Use `bundle exec guard` to automatically have tests run as you make changes.
 5. Make your changes.
+
+## Versioning
+
+This repository conforms to the semantic versioning convention:
+
+```
+v[MAJOR].[MINOR].[PATCH]
+```
+
+where
+
+      [MAJOR]   is incremented when an incompatible API change is made or a major milestone that significantly changes the library is achieved.
+
+      [MINOR]   is incremented when new functionality is introduced in a backward-compatible manner.
+
+      [PATCH]   is incremented when a backward-compatible bug fix is introduced.
+
+All updates should have a corresponding CHANGELOG.md entry that at a high-level describes what is being newly introduced in it.
+
+When incrementing a level any lower-levels should always reset to 0.

--- a/lib/shroud/gem_version.rb
+++ b/lib/shroud/gem_version.rb
@@ -1,3 +1,3 @@
 module Shroud
-  VERSION = "0.0.7".freeze
+  VERSION = "1.0.0".freeze
 end


### PR DESCRIPTION
This PR adds support for selecting a coverage type. The default value will be `instructions` to match the current behavoir.