### PR TITLE
Filter files by module, hide unmodified modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 - [danger-shroud](#danger-shroud)
   - [Installation](#installation)
+  - [Configuration](#configuration)
   - [Usage Kover](#usage-kover)
     - [Parameters](#parameters)
     - [Examples](#examples)
@@ -24,6 +25,12 @@ Add this line to your application's Gemfile:
 gem 'danger-shroud'
 ```
 
+## Configuration
+
+Shroud will default to using the filepath of your coverage report to determine which module the reported files belong to. This assumes that your Jacoco or Kover configuration will output to the default `build/reports/` directory when generating reports.
+
+If you have a custom configuration that outputs the reports somewhere else, you can provide the module's path with the `moduleDirectory` parameter. This allows the plugin to accurately determine the module in which a file is located by matching it to the file's path prefix. A custom report location that does not have a `moduleDirectory` specified may result in files being reported in modules they do not belong to.
+
 ## Usage Kover
 
 Shroud depends on having a Kover coverage report generated for your project. For Android projects, [kotlinx-kover](https://github.com/Kotlin/kotlinx-kover) works well. 
@@ -35,6 +42,7 @@ You can use the following parameters to control how shroud operates:
 | Param                       | Type    | Description                                                                                 | Example                      |
 |-----------------------------|---------|---------------------------------------------------------------------------------------------|------------------------------|
 | moduleName                  | String  | the display name of the project or module.                                                  | `'Module Name '`             |
+| moduleDirectory             | String, nil  | file path to the module to specify its location when its report `file` outputs to a custom directory.                     | default `nil`.               |
 | file                        | String  | file path to a Kover xml coverage report.                                                   | `'path/to/kover/report.xml'` |
 | totalProjectThreshold       | Integer | defines the required percentage of total project coverage for a passing build.              | default `90`                 |
 | modifiedFileThreshold       | Integer | defines the required percentage of files modified in a PR for a passing build.              | default `90`                 |
@@ -49,7 +57,7 @@ Running shroud with default values:
 ```ruby
 # Report coverage of modified files, fail if either total 
 # project coverage or any modified file's coverage is under 90%
-shroud.reportKover moduleName: 'Module Name', file: 'path/to/kover/report.xml'
+shroud.reportKover moduleName: 'Module Name', file: 'module/build/reports/kover/report.xml'
 ```
 
 Running shroud with custom coverage thresholds:
@@ -57,7 +65,7 @@ Running shroud with custom coverage thresholds:
 ```ruby
 # Report coverage of modified files, fail if total project coverage is under 80%,
 # or if any modified file's coverage is under 95%
-shroud.reportKover moduleName: 'Module Name', file: 'path/to/kover/report.xml', totalProjectThreshold: 80, modifiedFileThreshold: 95
+shroud.reportKover moduleName: 'Module Name', file: 'module/build/reports/kover/report.xml', totalProjectThreshold: 80, modifiedFileThreshold: 95
 ```
 
 Warn on builds instead of fail:
@@ -65,7 +73,15 @@ Warn on builds instead of fail:
 ```ruby
 # Report coverage of modified files the same as the above example, except the
 # builds will only warn instead of fail if below project thresholds
-shroud.reportKover moduleName: 'Module Name', file: 'path/to/kover/report.xml', totalProjectThreshold: 80, modifiedFileThreshold: 95, failIfUnderProjectThreshold: false, failIfUnderFileThreshold: false
+shroud.reportKover moduleName: 'Module Name', file: 'module/build/reports/kover/report.xml', totalProjectThreshold: 80, modifiedFileThreshold: 95, failIfUnderProjectThreshold: false, failIfUnderFileThreshold: false
+```
+
+Running shroud with a Kover report file in a custom directory:
+
+```ruby
+# Report coverage of modified files, specifying an explicit path to the module
+# when the coverage report won't be inside of its `build/reports/` directory
+shroud.reportKover moduleName: 'Module Name', moduleDirectory: 'module/', file: 'custom/path/to/kover/report.xml'
 ```
 
 ## Usage Jacoco
@@ -77,6 +93,7 @@ You can use the following parameters to control how shroud operates:
 | Param                       | Type    | Description                                                                                 | Example                       |
 |-----------------------------|---------|---------------------------------------------------------------------------------------------|-------------------------------|
 | moduleName                  | String  | the display name of the project or module.                                                  | `'Module Name '`              |
+| moduleDirectory             | String, nil  | file path to the module to specify its location when its report `file` outputs to a custom directory.                     | default `nil`.                |
 | file                        | String  | file path to a Jacoco xml coverage report.                                                  | `'path/to/jacoco/report.xml'` |
 | totalProjectThreshold       | Integer | defines the required percentage of total project coverage for a passing build.              | default `90`                  |
 | modifiedFileThreshold       | Integer | defines the required percentage of files modified in a PR for a passing build.              | default `90`                  |
@@ -93,7 +110,7 @@ Running shroud with default values:
 ```ruby
 # Report coverage of modified files, fail if either total 
 # project coverage or any modified file's coverage is under 90%
-shroud.reportJacoco moduleName: 'Module Name', file: 'path/to/jacoco/report.xml'
+shroud.reportJacoco moduleName: 'Module Name', file: 'project/module/reports/jacoco/report.xml'
 ```
 
 Running shroud with custom coverage thresholds:
@@ -101,7 +118,7 @@ Running shroud with custom coverage thresholds:
 ```ruby
 # Report coverage of modified files, fail if total project coverage is under 80%,
 # or if any modified file's coverage is under 95%
-shroud.reportJacoco moduleName: 'Module Name', file: 'path/to/jacoco/report.xml', totalProjectThreshold: 80, modifiedFileThreshold: 95
+shroud.reportJacoco moduleName: 'Module Name', file: 'module/reports/jacoco/report.xml', totalProjectThreshold: 80, modifiedFileThreshold: 95
 ```
 
 Warn on builds instead of fail:
@@ -109,7 +126,15 @@ Warn on builds instead of fail:
 ```ruby
 # Report coverage of modified files the same as the above example, except the
 # builds will only warn instead of fail if below thresholds
-shroud.reportJacoco moduleName: 'Module Name', file: 'path/to/jacoco/report.xml', totalProjectThreshold: 80, modifiedFileThreshold: 95, failIfUnderProjectThreshold: false, failIfUnderFileThreshold: false
+shroud.reportJacoco moduleName: 'Module Name', file: 'module/reports/jacoco/report.xml', totalProjectThreshold: 80, modifiedFileThreshold: 95, failIfUnderProjectThreshold: false, failIfUnderFileThreshold: false
+```
+
+Running shroud with a Jacoco report file in a custom directory:
+
+```ruby
+# Report coverage of modified files, specifying an explicit path to the module
+# when the coverage report won't be inside of its `build/reports/` directory
+shroud.reportKover moduleName: 'Module Name', moduleDirectory: 'module/', file: 'custom/path/to/jacoco/report.xml'
 ```
 
 ## Development

--- a/lib/shroud/plugin.rb
+++ b/lib/shroud/plugin.rb
@@ -234,6 +234,11 @@ module Danger
         end
       end
 
+      # don't output anything when the module has no touched files
+      if (touchedFilesHash.empty?)
+        return
+      end
+
       puts "Here are unreported files"
       puts fileNamesNotInReport.to_s
       puts "Here is the touched files coverage hash"

--- a/lib/shroud/plugin.rb
+++ b/lib/shroud/plugin.rb
@@ -68,7 +68,11 @@ module Danger
     # Report coverage on diffed files, as well as overall coverage.
     #
     # @param   [String] moduleName
-    #          the display name of the project or module
+    #          the display name of the project or module.
+    #
+    # @param   [String, nil] moduleDirectory
+    #          file path to the module to specify its location when its report `file` outputs to a custom directory.
+    #          default nil.
     #
     # @param   [String] file
     #          file path to a Jacoco xml coverage report.
@@ -96,6 +100,7 @@ module Danger
     # @return  [void]
     def reportJacoco(
       moduleName:,
+      moduleDirectory: nil,
       file:,
       totalProjectThreshold: 90,
       modifiedFileThreshold: 90,
@@ -106,6 +111,7 @@ module Danger
       internalReport(
         reportType: 'Jacoco',
         moduleName: moduleName,
+        moduleDirectory: moduleDirectory,
         file: file,
         totalProjectThreshold: totalProjectThreshold,
         modifiedFileThreshold: modifiedFileThreshold,
@@ -118,7 +124,11 @@ module Danger
     # Report coverage on diffed files, as well as overall coverage.
     #
     # @param   [String] moduleName
-    #          the display name of the project or module
+    #          the display name of the project or module.
+    #
+    # @param   [String, nil] moduleDirectory
+    #          file path to the module to specify its location when its report `file` outputs to a custom directory.
+    #          default nil.
     #
     # @param   [String] file
     #          file path to a Kover xml coverage report.
@@ -146,6 +156,7 @@ module Danger
     # @return  [void]
     def reportKover(
       moduleName:,
+      moduleDirectory: nil,
       file:,
       totalProjectThreshold: 90,
       modifiedFileThreshold: 90,
@@ -156,6 +167,7 @@ module Danger
       internalReport(
         reportType: 'Kover',
         moduleName: moduleName,
+        moduleDirectory: moduleDirectory,
         file: file,
         totalProjectThreshold: totalProjectThreshold,
         modifiedFileThreshold: modifiedFileThreshold,
@@ -168,6 +180,7 @@ module Danger
     private def internalReport(
       reportType:,
       moduleName:,
+      moduleDirectory:,
       file:,
       totalProjectThreshold:,
       modifiedFileThreshold:,
@@ -187,9 +200,17 @@ module Danger
       total = missed + covered
       coveragePercent = (covered / total.to_f) * 100
 
-      # get array of files names touched by this PR (modified + added)
-      touchedFileNames = @dangerfile.git.modified_files.map { |file| File.basename(file) }
-      touchedFileNames += @dangerfile.git.added_files.map { |file| File.basename(file) }
+      # if we are provided an explicit path to the module directory, use that.
+      # the default location for a Kover or Jacoco report is in the build directory of the module.
+      # if we're in the build directory then we can determine the module's file path for sorting.
+      modulePath = moduleDirectory || (file.include?('/build/') ? file.split('/build/').first + '/' : nil)
+
+      # get array of files names within the specified module touched by this PR (modified + added).
+      # if we have the path of the module, use that to filter the files, otherwise fallback to
+      # the previous behavior when it can't be determined.
+      touchedFileNames = (@dangerfile.git.modified_files + @dangerfile.git.added_files)
+        .select { |path| modulePath.nil? || path.start_with?(modulePath) }
+        .map { |path| File.basename(path) }
 
       # used to later report files that were modified but not included in the report
       fileNamesNotInReport = []


### PR DESCRIPTION
## Description
Fixes the following issues:

1. Shroud cannot determine which module a modified file belongs to. The "Modified Files Not Found In Coverage Report" section lists every file in the PR for every module it runs a report on. This is a bug, and it should only list files that belong to the module it's reporting on. 

2. Modules with no modified files should hide by default. Reporting the output of every module even when none of its files were changed and results in a really verbose output that gets in the way of the rest of a pull request.

After these changes, modified files (with or without coverage) will only appear under the module they are contained in, and modules with no touched files won't be reported by default. This PR also adds the `hideIfUntouched` flag, which can override the default hiding behavior on the off chance someone wants a certain module to display every time.

## Testing
### Great Clips
I tested these changes by taking this version of danger-shroud and committing it on top of a few open PRs in the Great Clips repo:

Before: [GCI-5596 PR](https://github.com/livefront/great-clips-android/pull/3176)
After: [Test PR](https://github.com/livefront/great-clips-android/pull/3179)

Before: [GCI-5532 PR](https://github.com/livefront/great-clips-android/pull/3170)
After: [Test PR 2](https://github.com/livefront/great-clips-android/pull/3180)

### Loupe
I have a PR open in Loupe that I applied these change on top of in different configurations to display different behaviors: 
Before: [Migrate Logging to Compose](https://github.com/livefront/loupe-android/pull/313)
After: [Migrate Logging to Compose with Shroud changes applied](https://github.com/livefront/loupe-android/pull/314)
With Custom Output Directory: [Test Shroud updates, Logging coverage to custom output directory](https://github.com/livefront/loupe-android/pull/316)
With Custom Output Directory and incorrectly configured `moduleDirectory`: [Test Shroud updates, nil moduleDirectory](https://github.com/livefront/loupe-android/pull/317)