### PR TITLE
Version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Change Log
 Version Next
 ----------------------------
 
+Version 2.1.0
+----------------------------
+* Filters touched files by module
+* Hides modules from report output when they have no changed files.
+
 Version 2.0.0
 ----------------------------
 * Upgrade to Ruby 3.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-shroud (2.0.0)
+    danger-shroud (2.1.0)
       danger-plugin-api (~> 1.0)
       nokogiri
 

--- a/lib/shroud/gem_version.rb
+++ b/lib/shroud/gem_version.rb
@@ -1,3 +1,3 @@
 module Shroud
-  VERSION = "2.0.0".freeze
+  VERSION = "2.1.0".freeze
 end


### PR DESCRIPTION
## Description
Bumps the version number and updates the changelog to trigger a release.

This version is exclusively the changes from https://github.com/livefront/danger-shroud/pull/52.